### PR TITLE
fix: current chat fire return 0

### DIFF
--- a/app/backend/daemons/chatlog_d.go
+++ b/app/backend/daemons/chatlog_d.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/gempir/go-twitch-irc/v3"
+	"github.com/gin-gonic/gin"
 	"log"
 	"tchatong.info/db"
 	"tchatong.info/models"
@@ -55,7 +56,9 @@ func crawlFromChannel(channel string, mariaDB *db.MariaDB, bigQueryDB *db.BigQue
 		if len(message.Message) >= 256 {
 			return
 		}
-		bigQueryDB.InsertRow(models.ChatLog{StreamerId: message.RoomID, StreamerLogin: message.Channel, Date: time.Now().UTC(), Content: message.Message})
+		if gin.Mode() == gin.ReleaseMode {
+			bigQueryDB.InsertRow(models.ChatLog{StreamerId: message.RoomID, StreamerLogin: message.Channel, Date: time.Now().UTC(), Content: message.Message})
+		}
 		conn, err := mariaDB.Query("INSERT INTO chatlog VALUES (?, ?, ?)", message.RoomID, time.Now().UTC(), message.Message)
 		defer func(conn *sql.Rows) {
 			err := conn.Close()

--- a/app/backend/services/chatfire_s.go
+++ b/app/backend/services/chatfire_s.go
@@ -73,10 +73,11 @@ func GetDayTopChatFire(streamerId string, mariaDB *db.MariaDB) models.ChatFireRe
 
 func GetCurrentChatFire(streamerId string, mariaDB *db.MariaDB) models.ChatFireResponse {
 	var chatFire models.ChatFire
+	var viewers sql.NullInt64
 
 	aMinuteAgo := time.Now().Add(time.Duration(-1) * time.Minute).Truncate(time.Minute)
-	_ = mariaDB.QueryRow("SELECT * FROM chatfire WHERE streamer_id=? AND date=?", streamerId, aMinuteAgo).Scan(&chatFire.Id, &chatFire.StreamerId, &chatFire.Date, &chatFire.Count)
-	return models.ChatFireResponse{Time: chatFire.Date, Count: chatFire.Count}
+	_ = mariaDB.QueryRow("SELECT * FROM chatfire WHERE streamer_id=? AND date=?", streamerId, aMinuteAgo).Scan(&chatFire.Id, &chatFire.StreamerId, &chatFire.Date, &chatFire.Count, &viewers)
+	return models.ChatFireResponse{Time: chatFire.Date, Count: chatFire.Count, Viewers: int(viewers.Int64)}
 }
 
 func GetChatFireByInterval(streamerId string, interval int, mariaDB *db.MariaDB) []models.ChatFireResponse {


### PR DESCRIPTION
현재 채팅 화력이 0을 반환하는 버그 수정 및 릴리즈 모드에서만 빅쿼리에 데이터 저장하도록 수정