### PR TITLE
fix: safari client side error(date parsing error)

### DIFF
--- a/app/backend/docs/chat-fire/streamerId/interval/get.md
+++ b/app/backend/docs/chat-fire/streamerId/interval/get.md
@@ -1,6 +1,7 @@
 # Show chat fire by streamer id and interval
 
 streamerId와 일치하는 스트리머의 채팅 화력 데이터를 interval에 맞게 가공해서 반환함
+시간은 KST 기준으로 반환함(+0900)
 
 URL: `/chat-fire/:streamerId/:interval`  
 Method: `GET`
@@ -12,23 +13,23 @@ Content:
 ```json
 [
   {
-    "time": "2022-05-30 06:00:00 +0000 UTC",
+    "time": "2022-05-30T06:00:00",
     "count": 689
   },
   {
-    "time": "2022-05-30 06:15:00 +0000 UTC",
+    "time": "2022-05-30T06:15:00",
     "count": 985
   },
   {
-    "time": "2022-05-30 06:30:00 +0000 UTC",
+    "time": "2022-05-30T06:30:00",
     "count": 2361
   },
   {
-    "time": "2022-05-30 06:45:00 +0000 UTC",
+    "time": "2022-05-30T06:45:00",
     "count": 1196
   },
   {
-    "time": "2022-05-30 07:00:00 +0000 UTC",
+    "time": "2022-05-30T07:00:00",
     "count": 701
   }
 ]


### PR DESCRIPTION
사파리에서는 "YYYY-MM-DD hh:mm:ss +0000 UTC" 형식의 시간을 파싱하지 못함.
그래서 "YYYY-MM-DDThh:mm:ss" KST 시간대로 API 응답 형식을 바꿈