### PR TITLE
chore: use alpine:3.12 instead of alpine:3 in telegraf

### DIFF
--- a/app/telegraf/Dockerfile
+++ b/app/telegraf/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.12
 
 RUN apk update && apk add telegraf
 


### PR DESCRIPTION
alpine 이미지가 두개 있어서 3.12 버전으로 통합